### PR TITLE
Using PreserveAspectCrop for all gamesetup images

### DIFF
--- a/src/qml/Icaion/GameSetupModel.qml
+++ b/src/qml/Icaion/GameSetupModel.qml
@@ -22,7 +22,7 @@ ObjectModel {
 
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup01.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -78,7 +78,7 @@ ObjectModel {
 
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup01b.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -99,7 +99,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup02.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -174,7 +174,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup03.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -208,7 +208,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup04.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -256,7 +256,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup05.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -290,7 +290,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup06.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -320,7 +320,7 @@ ObjectModel {
                 Image {
                     id: harvesterIcon
                     source: "qrc:/assets/images/game_setup/icaion/icon_harvester.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -351,7 +351,7 @@ ObjectModel {
                 Image {
                     id: scavengerIcon
                     source: "qrc:/assets/images/game_setup/icaion/icon_scavenger.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -382,7 +382,7 @@ ObjectModel {
                 Image {
                     id: refinersIcon
                     source: "qrc:/assets/images/game_setup/icaion/icon_refiners.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -474,7 +474,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup07.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -518,7 +518,7 @@ ObjectModel {
                 Image {
                     id: maximumHandsIcon
                     source: "qrc:/assets/images/game_setup/icaion/icon_max_hands.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -549,7 +549,7 @@ ObjectModel {
                 Image {
                     id: maximumUpgradeIcon
                     source: "qrc:/assets/images/game_setup/icaion/icon_max_curio_upgrades.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -574,7 +574,7 @@ ObjectModel {
             }
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup07b.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -609,7 +609,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup08.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -658,7 +658,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup09.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -692,7 +692,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup10.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -742,7 +742,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/icaion/setup11.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true

--- a/src/qml/Mysthea/GameSetupModel.qml
+++ b/src/qml/Mysthea/GameSetupModel.qml
@@ -22,7 +22,7 @@ ObjectModel {
 
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup01.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -73,7 +73,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup02.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -108,7 +108,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup03.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -144,7 +144,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup04.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -180,7 +180,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup05.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -216,7 +216,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup06.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -252,7 +252,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup07.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -302,7 +302,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup08.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -352,7 +352,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup09.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
                 borderWidth: 1
 
@@ -468,7 +468,7 @@ ObjectModel {
                 Image {
                     id: heroIcon
                     source: "qrc:/assets/images/game_setup/mysthea/hero.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -500,7 +500,7 @@ ObjectModel {
                 Image {
                     id: troopIcon
                     source: "qrc:/assets/images/game_setup/mysthea/icon_troop.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -532,7 +532,7 @@ ObjectModel {
                 Image {
                     id: golemIcon
                     source: "qrc:/assets/images/game_setup/mysthea/icon_golem.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -564,7 +564,7 @@ ObjectModel {
                 Image {
                     id: fortificationIcon
                     source: "qrc:/assets/images/game_setup/mysthea/fortification.svg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     sourceSize.width: 18
                     Layout.alignment: Qt.AlignTop
                     Layout.fillWidth: true
@@ -615,7 +615,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup10.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
 
                 Layout.fillWidth: true
@@ -665,7 +665,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/mysthea/setup11.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: width
 
                 Layout.fillWidth: true

--- a/src/qml/TheFall/GameSetupModel.qml
+++ b/src/qml/TheFall/GameSetupModel.qml
@@ -21,7 +21,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_1.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -56,7 +56,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_2.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -90,7 +90,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_3.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -124,7 +124,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_4.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -174,7 +174,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup-5.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -261,7 +261,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_6.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -295,7 +295,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_7.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -320,7 +320,7 @@ ObjectModel {
             }
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_7b.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -339,7 +339,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_8.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -373,7 +373,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_9.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -491,7 +491,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_10.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -553,7 +553,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup-11.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -588,7 +588,7 @@ ObjectModel {
             spacing: 20
             RoundedImage {
                 source: "qrc:/assets/images/game_setup/thefall/setup_12.jpg"
-                fillMode: Image.PreserveAspectFit
+                fillMode: Image.PreserveAspectCrop
                 width: root.width
                 borderWidth: 1
                 Layout.fillWidth: true
@@ -630,7 +630,7 @@ ObjectModel {
                 spacing: 20
                 RoundedImage {
                     source: "qrc:/assets/images/game_setup/thefall/setup_13a.jpg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     Layout.fillWidth: true
                     Layout.preferredHeight: 230
                     Layout.alignment: Qt.AlignTop
@@ -638,7 +638,7 @@ ObjectModel {
                 }
                 RoundedImage {
                     source: "qrc:/assets/images/game_setup/thefall/setup_13b.jpg"
-                    fillMode: Image.PreserveAspectFit
+                    fillMode: Image.PreserveAspectCrop
                     Layout.fillWidth: true
                     Layout.preferredHeight: 230
                     Layout.alignment: Qt.AlignTop


### PR DESCRIPTION
When using PreserveAspectFit, there are black bands around the image whit some aspect ratios, to solve this I made all the images' fillMode "PreserveAspectCrop"