### PR TITLE
TG-53: Fixed colors in CardsFiltersHeader and its children components.

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -133,6 +133,8 @@ ApplicationWindow {
                     Component {
                         Mysthea.CardsReference {
                             searchFieldBorderColor: Palette.pinkLavenderBlush
+                            searchFieldBorderFocusColor: Palette.darkPink
+                            comboBoxAccentColor: Palette.mystheaMain
                         }
                     },
                     Component {
@@ -163,7 +165,11 @@ ApplicationWindow {
 
                 appContents: [
                     Component {
-                        Icaion.CardsReference {}
+                        Icaion.CardsReference {
+                            searchFieldBorderColor: Palette.icaionLight
+                            searchFieldBorderFocusColor: Palette.icaionMain
+                            comboBoxAccentColor: Palette.icaionMain
+                        }
                     },
                     Component {
                         Icaion.GameSetup {}
@@ -193,7 +199,11 @@ ApplicationWindow {
 
                 appContents: [
                     Component {
-                        TheFall.CardsReference {}
+                        TheFall.CardsReference {
+                            searchFieldBorderColor: Palette.theFallLight
+                            searchFieldBorderFocusColor: Palette.theFallMain
+                            comboBoxAccentColor: Palette.theFallMain
+                        }
                     },
                     Component {
                         TheFall.GameSetup {}

--- a/src/style/MystheaUniverse/ComboBox.qml
+++ b/src/style/MystheaUniverse/ComboBox.qml
@@ -12,6 +12,7 @@ T.ComboBox {
     id: control
 
     property string iconRole
+    property color accentColor
 
     property bool iconAlignLeft: true
 
@@ -47,7 +48,7 @@ T.ComboBox {
             iconUrl: control.iconRole ? (Array.isArray(
                                              control.model) ? modelData[control.iconRole] : model[control.iconRole]) : ""
 
-            textColor: control.highlightedIndex === index ? Palette.mystheaMain : Palette.black
+            textColor: control.currentIndex === index ? control.accentColor : Palette.black
             iconAlignLeft: control.iconAlignLeft
         }
 

--- a/src/style/MystheaUniverse/Components/CardsFiltersHeader.qml
+++ b/src/style/MystheaUniverse/Components/CardsFiltersHeader.qml
@@ -12,6 +12,8 @@ ToolBar {
     property TypeProxyModel typeProxyModel: null
     property TypeComboBoxModel typeComboBoxModel: null
     property CommandComboBoxModel commandComboBoxModel: null
+    property color separatorFocusColor
+    property color comboBoxAccentColor
 
     signal comboboxValueChanged
 
@@ -26,6 +28,7 @@ ToolBar {
             id: _searchField
 
             borderColor: root.separatorColor
+            borderColorFocus: root.separatorFocusColor
             placeholderText: qsTr("Search cards by code")
             font.family: "FuturaPTBook"
             font.pixelSize: 18
@@ -55,6 +58,8 @@ ToolBar {
                 model: root.typeComboBoxModel
                 textRole: "type"
                 roleName: TypeComboBoxModel.IconUrl
+                accentColor: root.comboBoxAccentColor
+
 
                 Layout.fillWidth: true
 
@@ -80,6 +85,7 @@ ToolBar {
                 iconRole: root.commandComboBoxModel != null ? "iconUrl" : ""
                 roleName: CommandComboBoxModel.IconUrl
                 iconAlignLeft: true
+                accentColor: root.comboBoxAccentColor
 
                 Layout.fillWidth: root.commandComboBoxModel != null
 

--- a/src/style/MystheaUniverse/Components/SearchField.qml
+++ b/src/style/MystheaUniverse/Components/SearchField.qml
@@ -9,6 +9,7 @@ TextField {
     id: control
 
     property color borderColor
+    property color borderColorFocus: Palette.white
     signal resetSearchFieldClicked
 
     implicitHeight: 48
@@ -57,14 +58,13 @@ TextField {
 
     background: Rectangle {
         color: Palette.white
-        border.color: control.borderColor
-        border.width: 1
+        border.color: control.activeFocus ? control.borderColorFocus : control.borderColor
+        border.width: control.activeFocus ? 2 : 1
         radius: 5
     }
 
-
     onPreeditTextChanged: {
-        if(control.displayText.length > 0) {
+        if (control.displayText.length > 0) {
             _resetTextButton.visible = true
         } else {
             _resetTextButton.visible = false
@@ -72,7 +72,7 @@ TextField {
     }
 
     onTextEdited: {
-        if(control.text.length > 0) {
+        if (control.text.length > 0) {
             _resetTextButton.visible = true
         } else {
             _resetTextButton.visible = false

--- a/src/style/MystheaUniverse/Pages/CardsBasePage.qml
+++ b/src/style/MystheaUniverse/Pages/CardsBasePage.qml
@@ -13,6 +13,8 @@ Page {
       filters' combobox.
     */
     property color searchFieldBorderColor: Palette.white
+    property color searchFieldBorderFocusColor: Palette.white
+    property color comboBoxAccentColor: Palette.black
     property bool isLoading: _loader.status !== Loader.Ready
     property alias sourceComponent: _loader.sourceComponent
     property Action leftAction: null
@@ -32,6 +34,8 @@ Page {
             id: _filtersHeader
             width: parent.width
             separatorColor: root.searchFieldBorderColor
+            separatorFocusColor: root.searchFieldBorderFocusColor
+            comboBoxAccentColor: root.comboBoxAccentColor
             backgroundColor: Palette.black
 
             onComboboxValueChanged: {

--- a/src/style/MystheaUniverse/Pages/CardsReference.qml
+++ b/src/style/MystheaUniverse/Pages/CardsReference.qml
@@ -10,6 +10,8 @@ StackPage {
     objectName: PageName.cardPage
 
     property color searchFieldBorderColor
+    property color searchFieldBorderFocusColor
+    property color comboBoxAccentColor
     property Action leftAction: null
     property Component cardsListComponent: null
     // NOTE: Those models works only if all the apps have the same structure.
@@ -27,6 +29,8 @@ StackPage {
             typeComboBoxModel: root.typeComboBoxModel
             commandComboBoxModel: root.commandComboBoxModel
             searchFieldBorderColor: root.searchFieldBorderColor
+            searchFieldBorderFocusColor: root.searchFieldBorderFocusColor
+            comboBoxAccentColor: root.comboBoxAccentColor
             sourceComponent: root.typeProxyModel.size
                              > 0 ? root.cardsListComponent : emptyCardListComponent
         }


### PR DESCRIPTION
- Add `searchFiledBorderColor` for Icaion and TheFall.
- Add accent color for searchField for all the apps.
- Fix border width of searchField when it has the focus.
- Fix accent color in ComboBox because, in base of the app selected it is different.