### PR TITLE
TG-70: Fix SearchField compoment.

### DIFF
--- a/src/style/MystheaUniverse/Components/CardsFiltersHeader.qml
+++ b/src/style/MystheaUniverse/Components/CardsFiltersHeader.qml
@@ -36,6 +36,7 @@ ToolBar {
 
             onResetSearchFieldClicked: {
                 _searchField.clear()
+                _searchField.update()
                 root.typeProxyModel.setCodeFilter(_searchField.displayText)
             }
 

--- a/src/style/MystheaUniverse/Components/SearchField.qml
+++ b/src/style/MystheaUniverse/Components/SearchField.qml
@@ -38,21 +38,24 @@ TextField {
         verticalAlignment: control.verticalAlignment
     }
 
-    Image {
+    Button {
         id: _resetTextButton
-        anchors.right: control.right
-        width: 48
-        height: 48
-        source: "qrc:/assets/icons/clear_filter_icon.svg"
-        sourceSize.width: 48
-        sourceSize.height: 48
-        fillMode: Image.PreserveAspectFit
+        anchors.right: parent.right
+        height: parent.height
+        width: parent.height
         visible: false
 
-        MouseArea {
+        background: null
+
+        Image {
             anchors.fill: parent
-            onClicked: control.resetSearchFieldClicked()
+            source: "qrc:/assets/icons/clear_filter_icon.svg"
+            sourceSize.width: parent.width
+            sourceSize.height: parent.height
+            fillMode: Image.PreserveAspectFit
         }
+
+        onClicked: control.resetSearchFieldClicked()
     }
 
     background: Rectangle {
@@ -80,6 +83,6 @@ TextField {
 
     onResetSearchFieldClicked: {
         _resetTextButton.visible = false
-        control.forceActiveFocus()
+        control.focus = true
     }
 }


### PR DESCRIPTION
BUG: In  CardsReference page, when you write something on the search field and then click on reset search field button, the text will be cleaned up but the reset button is still visible. You have to click twice to hide it.

I changed the old compoment with a Button and I add an update call when the search field is cleaned up. 